### PR TITLE
Added innodb_default_row_format var to my.cnf template file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,6 +85,7 @@ mysql_innodb_log_file_size: "64M"
 mysql_innodb_log_buffer_size: "8M"
 mysql_innodb_flush_log_at_trx_commit: "1"
 mysql_innodb_lock_wait_timeout: "50"
+mysql_innodb_default_row_format: "dynamic"
 
 # These settings require MySQL > 5.5.
 mysql_innodb_large_prefix: "1"

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -81,6 +81,7 @@ innodb_log_file_size = {{ mysql_innodb_log_file_size }}
 innodb_log_buffer_size = {{ mysql_innodb_log_buffer_size }}
 innodb_flush_log_at_trx_commit = {{ mysql_innodb_flush_log_at_trx_commit }}
 innodb_lock_wait_timeout = {{ mysql_innodb_lock_wait_timeout }}
+innodb_default_row_format = {{ mysql_innodb_default_row_format }}
 
 [mysqldump]
 quick


### PR DESCRIPTION
With actual setting there is problem when someone uses utf8mb4 encoding. Index column with this encoding will result in ERROR 1709 (HY000): Index column size too large.

I've added variable to set by user and made id defaults to "dynamic".